### PR TITLE
style: enable format check in the tests

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -23,7 +23,7 @@ object playground extends ScalaModule with ScalafmtModule { m =>
     if (useChisel5) ivy"org.chipsalliance:::chisel-plugin:5.0.0" else
     ivy"edu.berkeley.cs:::chisel3-plugin:3.6.0",
   )
-  object test extends Tests with Utest {
+  object test extends Tests with Utest with ScalafmtModule {
     override def ivyDeps = m.ivyDeps() ++ Agg(
       ivy"com.lihaoyi::utest:0.8.1",
       if (useChisel5) ivy"edu.berkeley.cs::chiseltest:5.0-SNAPSHOT" else


### PR DESCRIPTION
Right now only files under `playground/src` can be reformatted. Also enable format check for files under `playground/test/src`.