### PR TITLE
Upgrade Chisel and Chisel Plugin Dependencies to Version 6.2.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -23,11 +23,11 @@ object playground extends SbtModule with ScalafmtModule { m =>
   }
   override def ivyDeps = Agg(
     if (useChisel3) ivy"edu.berkeley.cs::chisel3:3.6.0" else
-    ivy"org.chipsalliance::chisel:7.0.0-M1"
+    ivy"org.chipsalliance::chisel:6.2.0"
   )
   override def scalacPluginIvyDeps = Agg(
     if (useChisel3) ivy"edu.berkeley.cs:::chisel3-plugin:3.6.0" else
-    ivy"org.chipsalliance:::chisel-plugin:7.0.0-M1"
+    ivy"org.chipsalliance:::chisel-plugin:6.2.0"
   )
   object test extends SbtModuleTests with TestModule.ScalaTest with ScalafmtModule {
     override def sources = T.sources {


### PR DESCRIPTION
Updates the versions of the chisel library and the chisel-plugin to 6.2.0 to address compatibility issues with Verilator.

I'm using Verilator 5.027 and the ` make test ` instruction runs into the following error:

```
/usr/local/share/verilator/include/verilatedos.h:271:3: error: #error "Verilator requires a C++14 or newer compiler"
  271 | # error "Verilator requires a C++14 or newer compiler"
      |   ^~~~~
```

And it's fixed in https://github.com/chipsalliance/chisel/pull/3876

Upgrading the chisel library and the chisel-plugin to 6.2.0 fixes this issue.
